### PR TITLE
WIFI-7962: Add support for logdump call

### DIFF
--- a/proto.c
+++ b/proto.c
@@ -888,7 +888,8 @@ proto_handle_blob(void)
 		else if (!strcmp(method, "perform") ||
 			 !strcmp(method, "rtty") ||
 			 !strcmp(method, "wifiscan") ||
-			 !strcmp(method, "trace"))
+			 !strcmp(method, "trace") ||
+			 !strcmp(method, "logdump"))
 			action_handle(rpc, method, 0, 1);
 		else if (!strcmp(method, "leds"))
 			leds_handle(rpc);


### PR DESCRIPTION
This adds support for the logdump call, which will trigger cmd_logdump.uc.